### PR TITLE
"Calendar" button resized on the home page

### DIFF
--- a/css/navbar.css
+++ b/css/navbar.css
@@ -136,11 +136,18 @@ body{
     color: #2a95f6;
 }
 #Calender{
-    border: 1px solid #f6f8f9;
-    background-color:#208FF4 ;
+    border: 1px solid #208FF4;
+    background-color: transparent;
+    color: #2a95f6;
+    font-size: 14px;
+    padding: 10px 20px;
+    border-radius: 10px;
+    cursor: pointer;
+}
+
+#Calender:hover {
+    background-color: #208FF4;
     color: white;
-    font-size: 1.1rem;
-    padding: 1.2rem;
 }
 
 


### PR DESCRIPTION
## Related Issue
Closes #663:The "Calendar" button size need to resized on the home page 

## Description
In the updated navbar.css, the #Calender selector is now styled to match the #signup button. Adjustments have been made to the border, background color, font size, padding, and hover effects to ensure consistency.

## Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / Videos (if applicable)
Before "Calendar" button looked as:
![image](https://github.com/piug-07/blogzen-OpenSource/assets/166159211/cc14537e-a18d-404a-a936-b420a4a173cf)

After I made the changes:
![image](https://github.com/piug-07/blogzen-OpenSource/assets/166159211/619a8f49-bf40-4125-a21c-f809235bf0f5)


## Checklist:
- [X] I have performed a self-review of my code.
- [X] I have read and followed the Contribution Guidelines outlined in the project's documentation.
- [X] I have thoroughly tested the changes before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.


<!-- To check the boxes, place an 'X' inside the brackets. Example: [X] -->

